### PR TITLE
fix: 修复npm install 时canvas 依赖报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@vueuse/shared": "^10.6.1",
     "axios": "^1.6.0",
     "beautify-qrcode": "^1.0.3",
-    "canvas": "^2.11.2",
     "chroma-js": "^2.4.2",
     "clipboard": "^2.0.11",
     "clipper-lib": "^6.4.2",


### PR DESCRIPTION
canvas 依赖无用，直接删除